### PR TITLE
chore: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/examples/charts.yaml
+++ b/examples/charts.yaml
@@ -436,7 +436,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-config
-          image: docker.io/bitnami/kafka:4.0.0-debian-12-r10
+          image: docker.io/soldevelo/kafka:4.0.0-debian-12-r0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -596,7 +596,7 @@ spec:
           name: foobar
       containers:
         - name: kafka
-          image: docker.io/bitnami/kafka:4.0.0-debian-12-r10
+          image: docker.io/soldevelo/kafka:4.0.0-debian-12-r0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/examples/features.yaml
+++ b/examples/features.yaml
@@ -425,7 +425,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-config
-          image: docker.io/bitnami/kafka:4.0.0-debian-12-r10
+          image: docker.io/soldevelo/kafka:4.0.0-debian-12-r0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -585,7 +585,7 @@ spec:
           name: foobar
       containers:
         - name: kafka
-          image: docker.io/bitnami/kafka:4.0.0-debian-12-r10
+          image: docker.io/soldevelo/kafka:4.0.0-debian-12-r0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kafka:4.0.0-debian-12-r10` → [`soldevelo/kafka:4.0.0-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)